### PR TITLE
AUTOGENERATED: Promote latest Realm-Velocity image/artifact to production

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -2,4 +2,4 @@ resources:
   - velocity/
 images:
   - name: registry.runicrealms.com/build/realm-velocity
-    newTag: "8bd716ef2bef998b90d4b751e68fc58b732a55d4"
+    newTag: "cfcc352"

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -2,4 +2,4 @@ resources:
   - velocity/
 images:
   - name: registry.runicrealms.com/build/realm-velocity
-    newTag: "0edd2ea"
+    newTag: "702d5cc"

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -2,4 +2,4 @@ resources:
   - velocity/
 images:
   - name: registry.runicrealms.com/build/realm-velocity
-    newTag: "cfcc352"
+    newTag: "0edd2ea"


### PR DESCRIPTION
This PR promotes the latest tested Realm-Velocity build from dev to production. This was triggered because of a push to Realm-Velocity on ref main.